### PR TITLE
add vendor folder in manifest declaration

### DIFF
--- a/whoops/whoops.xml
+++ b/whoops/whoops.xml
@@ -14,6 +14,7 @@
     <files>
         <filename plugin="whoops">whoops.php</filename>
         <filename plugin="whoops">index.html</filename>
+        <folder>vendor</folder>
     </files>
 
     <languages folder="language">


### PR DESCRIPTION
Required so Joomla copies the folder during installation.